### PR TITLE
Remove PrintersWindow title

### DIFF
--- a/ui/PrintersWindow.ui
+++ b/ui/PrintersWindow.ui
@@ -5,7 +5,6 @@
   <object class="GtkWindow" id="PrintersWindow">
     <property name="width_request">400</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">System-Config-Printer</property>
     <property name="window_position">center</property>
     <property name="default_width">450</property>
     <property name="default_height">250</property>


### PR DESCRIPTION
There is no point in making this property translatable. In fact, there
is no point in having this property at all, because the title of the
window is reset when the program starts.